### PR TITLE
出品機能の本番環境での調整

### DIFF
--- a/db/migrate/20200503065624_change_column_to_not_null.rb
+++ b/db/migrate/20200503065624_change_column_to_not_null.rb
@@ -1,0 +1,11 @@
+class ChangeColumnToNotNull < ActiveRecord::Migration[5.2]
+  def change
+    def up
+      change_column :imtes, :saler_id, :string, null: true
+    end
+  
+    def down
+      change_column :items, :saler_id, :string, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_02_144921) do
+ActiveRecord::Schema.define(version: 2020_05_03_065624) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -27,6 +27,14 @@ ActiveRecord::Schema.define(version: 2020_05_02_144921) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
+
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "ancestry"
+    t.index ["ancestry"], name: "index_categories_on_ancestry"
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -53,13 +61,6 @@ ActiveRecord::Schema.define(version: 2020_05_02_144921) do
     t.integer "trading_status_id", default: 1
     t.index ["buyer_id"], name: "index_items_on_buyer_id"
     t.index ["saler_id"], name: "index_items_on_saler_id"
-
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "ancestry"
-    t.index ["ancestry"], name: "index_categories_on_ancestry"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# What
出品機能を本番環境で確認時に、EC2のDBテーブルのカラムに一意制約がかかっていることでエラーが発生したため、その修正

# Why
出品機能の実装のために必要不可欠であるため