### PR TITLE
購入確認画面の実装

### DIFF
--- a/app/assets/stylesheets/pages/items/_show.scss
+++ b/app/assets/stylesheets/pages/items/_show.scss
@@ -9,7 +9,7 @@
       &--form {
         .itembox {
           background-color: #fff;
-          padding: 24px 40px 40px;
+          padding: 24px 70px 40px;
           &__name {
             text-align: center;
             font-weight: bold;

--- a/app/assets/stylesheets/pages/users/_cards.scss
+++ b/app/assets/stylesheets/pages/users/_cards.scss
@@ -1,18 +1,15 @@
 .card-container{
   text-align: center;
-  &__title{
-    font-size: 35px;
-    height: 100px;
-    padding-top: 20px;
-  }
+  background-color: #f8f8f8;
   .card-wrapper{
-    border: 20px solid $mainblueColor;
     width: 50%;
-    margin: 50px auto;
+    margin: 0 auto;
     padding: 20px;
     max-width: 400px;
     img{
       width: 100px;
+      display: block;
+      margin: 0 auto;
     }
     .creditcard-info__period{
       .btn-card{

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -3,7 +3,7 @@ class CardsController < ApplicationController
   before_action :set_category_brand
   before_action :set_card
   before_action :set_payjp_api, except: [:new]
-  before_action :set_item
+  before_action :set_item, only: [:buy, :check]
   
   def index
     if @card.present?

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -3,6 +3,7 @@ class CardsController < ApplicationController
   before_action :set_category_brand
   before_action :set_card
   before_action :set_payjp_api, except: [:new]
+  before_action :set_item
   
   def index
     if @card.present?
@@ -34,7 +35,6 @@ class CardsController < ApplicationController
   end
 
   def buy
-    @item = Item.find(params[:id])
     if @item.buyer_id.present? 
       redirect_to item_path(@item)
     elsif @card.blank?
@@ -50,7 +50,6 @@ class CardsController < ApplicationController
   end
 
   def check
-    @item = Item.find(params[:id])
     customer    = Payjp::Customer.retrieve(@card.payjp_id)
       @card_info  = customer.cards.retrieve(customer.default_card)
       @card_brand = @card_info.brand
@@ -59,6 +58,11 @@ class CardsController < ApplicationController
   end
 
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def set_category_brand
     @parents = Category.where(ancestry: nil)
     @brands = ["シャネル","ナイキ", "ルイヴィトン", "シュプリーム","アディダス"]

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -45,8 +45,17 @@ class CardsController < ApplicationController
         customer: @card.payjp_id,
         currency: 'jpy'
       )
-      @item.update(buyer_id: current_user.id) ? (redirect_to root_path) : (redirect_to item_path(@item))
+      @item.update(buyer_id: current_user.id) ? (redirect_to item_path(@item)) : (redirect_to root_path)
     end
+  end
+
+  def check
+    @item = Item.find(params[:id])
+    customer    = Payjp::Customer.retrieve(@card.payjp_id)
+      @card_info  = customer.cards.retrieve(customer.default_card)
+      @card_brand = @card_info.brand
+      @exp_month  = @card_info.exp_month.to_s
+      @exp_year   = @card_info.exp_year.to_s.slice(2,3) 
   end
 
   private

--- a/app/views/cards/check.html.haml
+++ b/app/views/cards/check.html.haml
@@ -1,0 +1,41 @@
+.wrapper
+  = render "shared/header"
+
+  .main
+    .main-item
+      .main-item__content
+        .main-item__content--form
+          .itembox
+            %h2.itembox__name
+              = @item.name
+              .itembox__image
+              .mini-image
+                - @item.images.each do |image|
+                  .mini-images
+                    =image_tag image.image.url
+            .itembox__price
+              %span
+                ¥
+                = @item.price
+              .itembox__price--detail
+                %span
+                  (税込)
+                %span
+                  送料込み
+
+  .card-container
+    .card-wrapper
+      %h2.card-wrapper__title
+        購入内容の確認
+        = image_tag "visa-card.png"
+        %h3 カード番号  
+        %p.creditcard-info__number
+          = "**** **** **** " + @card_info.last4
+        %h3 有効期限 月 / 年
+        %p.creditcard-info__period 
+          = @exp_month + " / " + @exp_year
+        .creditcard-info__period
+          = button_to "このカードで買う", buy_card_path(@item.id), method: :get, class: "btn-card"
+          = button_to "トップページへ", root_path, method: :get, class: "btn-card"
+
+  = render "shared/form-footer"

--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -21,5 +21,4 @@
           %i.far.fa-credit-card 
           = button_to "クレジットカードを追加する", new_card_path, method: :get, class: "btn-card"
 
-  = render "shared/footer"
-
+  = render "shared/form-footer"

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -3,6 +3,8 @@
 
   .card-container
     .card-wrapper
+      %h2.card-wrapper__title
+        クレジットカード登録
       = form_with url: cards_path, method: :post, id: "payjp__form" do |f|
         .form__upper
           .form__upper__group
@@ -23,5 +25,5 @@
             = f.text_field :cvc, name: "cvc", id:"cvc", class: 'input-default',placeholder: '3~4文字、半角数字のみ', maxlength: "4"
           .form__upper__group
             = f.submit '次へ進む', class: 'btn-default',id: "charge-form"
-            
-  = render "shared/footer"
+
+  = render "shared/form-footer"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -39,7 +39,7 @@
               - elsif user_signed_in? && @item.saler_id != current_user.id
                 .itembox__detail--buy
                   %button.itembox__detail--buy--btn
-                    = link_to "購入購入画面に進む",buy_card_path(@item.id) 
+                    = link_to "購入する",check_card_path(@item.id) 
               - elsif user_signed_in? && @item.saler_id = current_user.id
                 .itembox__detail--edit
                   %button.itembox__detail--edit--btn

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   resources :categories, only: [:index, :show] 
   resources :cards, except: [:show,:edit,:update] do
     member do
+      get 'check'
       get 'buy'
     end
   end


### PR DESCRIPTION
### what

購入確認画面の実装
[https://i.gyazo.com/52858e90abbfd377a115be0b51a3cedf.png](url)
[https://gyazo.com/4bb1406518c8bdd1942b10d50cefa5f4](url)
[https://gyazo.com/f0ded8c57a4b2478c60422a537f4af37](url)
[https://gyazo.com/d4bf78f26d0ddbe1adfd792e6d1ce914](url)
1. checkメソッドを定義して、確認画面check viewに遷移する。
1. 登録したカード・価格を確認して購入する。
1. 商品がSOLDになった画面で、購入を確認する。
### why

1. 意図しない購入を避けるため。