### PR TITLE
出品機能におけるエラーの解消

### DIFF
--- a/app/assets/javascripts/item_new.js
+++ b/app/assets/javascripts/item_new.js
@@ -60,7 +60,7 @@ $(function() {
     `
     $('#delivery_charge').parent().append(sellerChargeOptions);
   }
-  // 送料別（購入者負担）の場合の配送方法の選択肢　→　ここもajax通信で取れるならとってきたい
+  // 送料別（購入者負担）の場合の配送方法の選択肢 → ここもajax通信で取れるならとってきたい
   function buyerCharge() {
     const buyerChargeOptions = `
       <div class='field' id='buyer-charge'>
@@ -85,7 +85,7 @@ $(function() {
   $(document).on('change', '#item_delivery_charge_flag', function (){
     const sellerChargeMethod = $('#seller-charge')
     const buyerChargeMethod = $('#buyer-charge')  
-    // $("select[name='item[delivery_method_id]'] option").attr("selected", false);
+    $("select[name='item[delivery_method_id]'] option").attr("selected", false);
     const chargeFlag = $(this).val();
     if (chargeFlag == "") {
       sellerChargeMethod.remove();

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
-  before_action :set_category_brand, only: [:index, :new, :show, :edit, :update]
+  before_action :set_category_brand, only: [:index, :new, :create, :show, :edit, :update]
 
   def index
     @items = Item.includes(:images).order('created_at DESC')
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save!
-      params[:item][:image].each do |image|
+      params[:item_images][:image].each do |image|
         @item.images.create(image: image, item_id: @item.id)
       end
       redirect_to items_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -67,6 +67,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @user = User.find_by(id: @item.saler_id)
     redirect_to root_path if @item == nil
   end 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -56,7 +56,8 @@
                   %tr
                     %th 出品者
                     %td
-                      =@item.name
+                      = link_to user_path do
+                        = @user.nickname
                   %tr
                     %th カテゴリー
                     %td


### PR DESCRIPTION
#What
-商品出品時に画像が登録されないエラーの解消

#Why
-商品情報編集機能を追加実装する際に、商品出品機能の記述を若干改変したために画像を付属させて商品出品が出来ない不具合の解消

##Sub
-商品詳細ページにおいて、商品出品者が表示されるように記述を変更