### PR TITLE
fix_#144

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -89,7 +89,7 @@ class ItemsController < ApplicationController
     @search_parents = Category.where(ancestry: nil).where.not(name: "カテゴリー一覧").pluck(:name)
 
     sort = params[:sort] || "created_at DESC"
-    @q = Item.includes(:images).search(search_params)
+    @q = Item.includes(:images).where.not(trading_status_id: 4).search(search_params)
     @items = @q.result(distinct: true).order(sort)
 
     # 販売状況が検索条件にあるとき


### PR DESCRIPTION
# What
検索結果に、下書き(tranding_status_id=4)の商品を表示しないように修正

# Why
下書きは購入も閲覧もできない仕様を実現するため