### PR TITLE
ItemsTableのカラム型修正に伴う一部コードの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Things you may want to cover:
 |birthday|date|null: false|
 
 ### Association
-- has_many :saling_items, -> { where(buyer_id is NULL) }, foreign_key: saler_id,     class_name: item
-- has_many :sold_items, -> { where(buyer_id is not NULL) }, foreign_key: saler_id, class_name: item
+- has_many :saler_items, foreign_key: saler_id, class_name: item
 - has_many :buyed_items, foreign_key: buyer_id, class_name: Item
 - has_many :likes
 - has_many :from_messages, class_name: "Message", foreign_key: "from_id"

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -57,8 +57,6 @@ class ItemsController < ApplicationController
   def show
     if @item == nil || @item.trading_status_id == 4
       redirect_to root_path 
-    else
-      @user = User.find_by(id: @item.saler_id)
     end
   end 
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -21,8 +21,7 @@ class MessagesController < ApplicationController
   private
 
   def send_message_to_user?
-    trading_item_users(@item)
-    @to_user = @saler_user == current_user ?  @buyer_user : @saler_user
+    @to_user = @item.saler == current_user ?  @item.buyer : @item.saler
   end
 
   def set_all_messages

--- a/app/helpers/trading_helper.rb
+++ b/app/helpers/trading_helper.rb
@@ -1,8 +1,4 @@
 module TradingHelper
-  def trading_item_users(item)
-    @saler_user = User.find(item.saler_id)
-    @buyer_user = User.find(item.buyer_id)
-  end
 
   def trading_item_fee(item)
     price = item.price * 0.1 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,6 +4,8 @@ class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :messages, class_name: "Message" ,foreign_key: "room_id", dependent: :destroy
+  belongs_to :buyer, class_name: "User", optional: true
+  belongs_to :saler, class_name: "User"
   belongs_to :category
   accepts_nested_attributes_for :images, allow_destroy: true
   extend ActiveHash::Associations::ActiveRecordExtensions
@@ -15,11 +17,13 @@ class Item < ApplicationRecord
 
   scope :desc,                 -> {order('created_at DESC')}
   scope :including,            -> {includes(:images)}
+  scope :saling,               -> {where(buyer_id: nil)}
+  scope :sold,                 -> {where.not(buyer_id: nil)}
   scope :trading_not,          -> {where.not(trading_status_id: 4..5)}
   scope :category,             -> (category_id)       {where(category_id: category_id)}
   scope :draft,                -> (saler_id)          {including.where(saler_id: saler_id).where(trading_status_id: 4)}
-  scope :exhibition,           -> (saler_id)          {including.where(saler_id: saler_id).where(buyer_id: nil).trading_not}
-  scope :exhibition_trading,   -> (saler_id)          {including.where(saler_id: saler_id).where.not(buyer_id: nil).trading_not}
+  scope :exhibition,           -> (saler_id)          {including.where(saler_id: saler_id).saling.trading_not}
+  scope :exhibition_trading,   -> (saler_id)          {including.where(saler_id: saler_id).sold.trading_not}
   scope :exhibition_completed, -> (saler_id)          {including.where(saler_id: saler_id).where(trading_status_id: 5)}
   scope :bought,               -> (buyer_id)          {including.where(buyer_id: buyer_id).trading_not}
   scope :bought_completed,     -> (buyer_id)          {including.where(buyer_id: buyer_id).where(trading_status_id: 5)}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,9 @@ class User < ApplicationRecord
   has_one  :sales_price,                                                 dependent: :destroy
   has_one  :point,                                                       dependent: :destroy
   has_many :likes,                                                       dependent: :destroy
-  has_many :from_messages,class_name: "Message" ,foreign_key: "from_id", dependent: :destroy
+  has_many :from_messages,class_name: "Message",foreign_key: "from_id",  dependent: :destroy
+  has_many :saler_items,  class_name: "Item",   foreign_key: "saler_id", dependent: :destroy  
+  has_many :buyed_items,  class_name: "Item",   foreign_key: "buyer_id", dependent: :destroy
 
   
   

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -51,7 +51,7 @@
                     %th 出品者
                     %td
                       = link_to user_path do
-                        = @user.nickname
+                        = @item.saler.nickname
                   %tr
                     %th カテゴリー
                     %td

--- a/app/views/shared/_header-nav_signed-in.html.haml
+++ b/app/views/shared/_header-nav_signed-in.html.haml
@@ -28,9 +28,10 @@
         = current_user.nickname.truncate(15, omission: '...')
       .user__details
         = link_to "#", class: "user__detaild--evaluation user__details--link" do
-          %span 評価：１
-        = link_to "#", class: "user__detaild--saled user__details--link" do
-          %span 出品数：１   
+          %span 評価： １
+        = link_to exhibition_users_path, class: "user__detaild--saled user__details--link" do
+          %span 出品数：   
+          = current_user.saler_items.saling.count
     .mypage__container--menu
       .menu__sales
         = render "shared/header-price_point"

--- a/app/views/trading/_main-box.html.haml
+++ b/app/views/trading/_main-box.html.haml
@@ -2,7 +2,7 @@
   .likes__title
     取引画面
   .content__trading{id: "trading__box"}
-    = render partial: 'trading_status', locals: { item: @item , saler_user: @saler_user, buyer_user: @buyer_user}
+    = render partial: 'trading_status', locals: { item: @item , saler_user: @item.saler, buyer_user: @item.buyer}
   .dm__box
     #trading__messages
       = render partial: 'messages/index', locals: { messages: @messages , item: @item}

--- a/app/views/trading/_side-box.html.haml
+++ b/app/views/trading/_side-box.html.haml
@@ -11,13 +11,13 @@
         .item__name
           = @item.name.truncate(15, omission: '...')
         .saler__user
-          = @saler_user.nickname.truncate(15, omission: '...')
+          = @item.saler.nickname.truncate(15, omission: '...')
     .item__information
       .item__information__title
         発送日数
       .item__information__box
         = @item.delivery_date.name
-    - if @saler_user == current_user
+    - if @item.saler == current_user
       .item__information
         .item__information__title
           送料
@@ -47,7 +47,7 @@
           お支払い金額
         .item__information__box
           = "#{@item.price.to_s(:delimited)}円"
-  - if @saler_user == current_user
+  - if @item.saler == current_user
     .trading__information
       .trading__information__title
         購入者情報
@@ -56,7 +56,7 @@
           .item__information__title
             購入者ニックネーム
           .item__information__box
-            = @buyer_user.nickname.truncate(15, omission: '...')
+            = @item.buyer.nickname.truncate(15, omission: '...')
       .trading__information__box
         .item__information
           .item__information__title
@@ -72,7 +72,7 @@
           .item__information__title
             出品者ニックネーム
           .item__information__box
-            = @saler_user.nickname.truncate(15, omission: '...')
+            = @item.saler.nickname.truncate(15, omission: '...')
       .trading__information__box
         .item__information
           .item__information__title

--- a/app/views/trading/cancel.js.haml
+++ b/app/views/trading/cancel.js.haml
@@ -1,3 +1,3 @@
-$("#trading__box").html("#{escape_javascript(render partial: 'trading_status', locals: { item: @item, saler_user: @saler_user, buyer_user: @buyer_user})}")
+$("#trading__box").html("#{escape_javascript(render partial: 'trading_status', locals: { item: @item, saler_user: @item.saler, buyer_user: @item.buyer})}")
 $("#message__form").html("#{escape_javascript(render partial: 'form', locals: { item: @item, message: @message})}")
 $("#trading__messages").html("#{escape_javascript(render partial: 'messages/index', locals: { messages: @messages, item: @item})}")

--- a/app/views/trading/update.js.haml
+++ b/app/views/trading/update.js.haml
@@ -1,3 +1,3 @@
-$("#trading__box").html("#{escape_javascript(render partial: 'trading_status', locals: { item: @item, saler_user: @saler_user, buyer_user: @buyer_user})}")
+$("#trading__box").html("#{escape_javascript(render partial: 'trading_status', locals: { item: @item, saler_user: @item.saler, buyer_user: @item.buyer})}")
 $("#message__form").html("#{escape_javascript(render partial: 'form', locals: { item: @item, message: @message})}")
 $(".menu__sales").html("#{escape_javascript(render partial: 'shared/header-price_point')}")

--- a/app/views/users/_show-action.html.haml
+++ b/app/views/users/_show-action.html.haml
@@ -9,6 +9,7 @@
         評価
       %p
         出品数
+        = current_user.saler_items.saling.count
 
   .mypage-tab-container-notification-todo
     .mypage-tabs

--- a/db/migrate/20200606191430_remove_saler_id_from_items.rb
+++ b/db/migrate/20200606191430_remove_saler_id_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveSalerIdFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :saler_id, :integer
+  end
+end

--- a/db/migrate/20200606191545_remove_buyer_id_from_items.rb
+++ b/db/migrate/20200606191545_remove_buyer_id_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveBuyerIdFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :buyer_id, :integer
+  end
+end

--- a/db/migrate/20200606191842_add_user_to_items.rb
+++ b/db/migrate/20200606191842_add_user_to_items.rb
@@ -1,0 +1,5 @@
+class AddUserToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :saler, foreign_key: { to_table: :users }, null: false
+  end
+end

--- a/db/migrate/20200606192635_add_buyer_to_items.rb
+++ b/db/migrate/20200606192635_add_buyer_to_items.rb
@@ -1,0 +1,5 @@
+class AddBuyerToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :buyer, foreign_key: { to_table: :users }, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_04_090604) do
+ActiveRecord::Schema.define(version: 2020_06_06_192635) do
 
   create_table "accounts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -64,8 +64,6 @@ ActiveRecord::Schema.define(version: 2020_06_04_090604) do
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "buyer_id"
-    t.integer "saler_id"
     t.string "name", null: false
     t.text "explanation"
     t.integer "delivery_charge_flag", null: false
@@ -78,16 +76,20 @@ ActiveRecord::Schema.define(version: 2020_06_04_090604) do
     t.integer "delivery_method_id"
     t.integer "trading_status_id", default: 1
     t.bigint "category_id", null: false
+    t.bigint "saler_id", null: false
+    t.bigint "buyer_id"
     t.index ["buyer_id"], name: "index_items_on_buyer_id"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["saler_id"], name: "index_items_on_saler_id"
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "item_id"
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_likes_on_item_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -141,6 +143,8 @@ ActiveRecord::Schema.define(version: 2020_06_04_090604) do
   add_foreign_key "cards", "users"
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
+  add_foreign_key "items", "users", column: "buyer_id"
+  add_foreign_key "items", "users", column: "saler_id"
   add_foreign_key "likes", "items"
   add_foreign_key "likes", "users"
   add_foreign_key "messages", "items", column: "room_id"


### PR DESCRIPTION
# what
- saler_id,buyer_idに外部キー制約
- 上の変更に伴う、一部記述の変更
- 出品数などの表示追加
# why
- 外部キー制約をつけることで、整合性のあるテーブル設計とすることができるため
- 不要記述が存在していたため
- 出品数を、視覚的に認知させるため