### PR TITLE
検索結果の並び替えに、「お気に入り!の多い順」を追加

### DIFF
--- a/app/assets/javascripts/item_search.js
+++ b/app/assets/javascripts/item_search.js
@@ -11,6 +11,7 @@ $(function() {
       case 'price-desc': html = "&sort=price+desc"; break;
       case 'created_at-asc': html = "&sort=created_at+asc"; break;
       case 'created_at-desc': html = "&sort=created_at+desc"; break;
+      case 'likes-desc': html = "&sort=likes_count_desc"; break;
       default: html = "&sort=created_at+desc"; 
     }
     // 現在の表示ページ
@@ -38,7 +39,8 @@ $(function() {
         case "price+desc": var sort = 2; break;
         case "created_at+asc": var sort = 3; break;
         case "created_at+desc": var sort = 4; break;
-        default: var sort = 4
+        case "likes_count_desc": var sort = 5; break;
+        default: var sort = 0
       }
       const add_selected = $('select[name=sort_order]').children()[sort]
       $(add_selected).attr('selected', true)

--- a/app/assets/javascripts/item_search.js
+++ b/app/assets/javascripts/item_search.js
@@ -326,6 +326,7 @@ $(function () {
         .prop("checked", false)
         .prop("selected", false)
     ;
+    $('select[name=sort_order]').children().first().attr('selected', true);
     $('#children_category_search').remove();
     $('#grandchildren_category_checkboxes').remove();
   }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -89,18 +89,19 @@ class ItemsController < ApplicationController
     @search_parents = Category.where(ancestry: nil).where.not(name: "カテゴリー一覧").pluck(:name)
 
     sort = params[:sort] || "created_at DESC"      
-    @q = Item.includes(:images).where.not(trading_status_id: 4).search(search_params)
+    @q = Item.not_draft.search(search_params)
     if sort == "likes_count_desc"
       @items = @q.result(distinct: true).select('items.*', 'count(likes.id) AS likes')
         .left_joins(:likes)
         .group('items.id')
-        .order('likes DESC').order('created_at DESC')
+        .order('likes DESC')
+        .desc
     else
       @items = @q.result(distinct: true).order(sort)
     end
     # 販売状況が検索条件にあるとき
     if trading_status_key = params.require(:q)[:trading_status_id_in]
-      @q = Item.includes(:images).search(search_params_for_trading_status)
+      @q = Item.including.search(search_params_for_trading_status)
       if trading_status_key.count == 1 && trading_status_key == ["3"]
         sold_items = Item.where.not(buyer_id: nil)
         @items = @items & sold_items

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,4 @@
 class Item < ApplicationRecord
-  # belongs_to :buyer, class_name: User
-  # belongs_to :saler, class_name: User
   has_many :images, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :messages, class_name: "Message" ,foreign_key: "room_id", dependent: :destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,6 +15,7 @@ class Item < ApplicationRecord
 
   scope :desc,                 -> {order('created_at DESC')}
   scope :including,            -> {includes(:images)}
+  scope :not_draft,            -> {including.where.not(trading_status_id: 4)}
   scope :trading_not,          -> {where.not(trading_status_id: 4..5)}
   scope :category,             -> (category_id)       {where(category_id: category_id)}
   scope :draft,                -> (saler_id)          {including.where(saler_id: saler_id).where(trading_status_id: 4)}

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -15,6 +15,8 @@
               出品の古い順
             %option{value: "created_at-desc"}
               出品の新しい順
+            %option{value: "likes-desc"}
+              お気に入り!の多い順
         .sc-side__detail
           = search_form_for(@q, url: search_items_path, id: 'item_search_form') do |f|
             %h4.sc-side__detail__title


### PR DESCRIPTION
# What
検索結果の並び替えを選択するプルダウンに、「お気に入り!の多い順」を追加

# Why
より商品を多角的に検索できるようにし、UXを向上させるため
