### PR TITLE
Fix #164

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :redirect_to_root, only: [:render_404]
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :basic_auth, if: :production?
@@ -29,6 +30,10 @@ class ApplicationController < ActionController::Base
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
+  end
+
+  def redirect_to_root
+    redirect_to root_path
   end
 
   def set_item_search_query

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -18,7 +18,7 @@ class CardsController < ApplicationController
     render :new if params[:payjpToken].blank?
     customer = Payjp::Customer.create(card: params[:payjpToken])
     @card    = Card.new(user_id: current_user.id, payjp_id: customer.id)
-    @card.save! ? (redirect_to cards_path) : (render :new)
+    @card.save! ? (redirect_to request.referer) : (render :new)
   end
 
   def destroy    

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  skip_before_action :authenticate_user!, except: [:new, :edit, :create, :update, :destroy]
+  skip_before_action :authenticate_user!, only: [:index, :show, :search]
   before_action :set_item_search_query, expect: [:search]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_present?, only: [:show, :edit]
@@ -7,6 +7,7 @@ class ItemsController < ApplicationController
   
 # 未ログインで行えるアクション
   def index
+    redirect_to root_path
   end
 
   def show

--- a/app/views/trading/_side-box.html.haml
+++ b/app/views/trading/_side-box.html.haml
@@ -12,6 +12,7 @@
           = @item.name.truncate(15, omission: '...')
         .saler__user
           = @saler_user.nickname.truncate(15, omission: '...')
+        = link_to "商品ページを確認する", item_path(@item)
     .item__information
       .item__information__title
         発送日数


### PR DESCRIPTION
# What
#161 のデプロイ後の微修正
・存在しないURLへアクセスした際に、サインイン画面に遷移しないように修正
・商品購入ボタン→カード情報登録後、元の商品ページにリダイレクトするように修正
・取引画面から該当商品ページにアクセスするリンクの設置

# Why
ユーザビリティの向上のため