### PR TITLE
リンク先のないリンクの削除orリンク設置、レイアウト修正

### DIFF
--- a/app/assets/stylesheets/modules/_category.scss
+++ b/app/assets/stylesheets/modules/_category.scss
@@ -1,5 +1,9 @@
 
-.category__child, .category__parent, .category__grandchild{
+.category__parent {
+  display: none;
+  border-top: solid 1px $lightgray;
+}
+.category__child, .category__grandchild{
   display: none;
 }
 
@@ -27,9 +31,10 @@
 // カテゴリーの大枠の要素の共通項
 .category__list{
   position: absolute;
-  height: 560px;
+  height: 588px;
   background-color: white;
-  border-right: 1px solid $whitesmoke;
+  border-right: 1px solid $lightgray;
+  border-bottom: solid 1px $lightgray;
   z-index: 1000;
 }
 
@@ -39,7 +44,7 @@
   color: black;
   display: block;
   padding: 5px 15px;
-  font-size: 11px;
+  font-size: 13px;
   letter-spacing: 2px;
   z-index: 1000;
 }
@@ -55,7 +60,7 @@
         width: 100%;
         color: black;
         display: block;
-        padding: 11px 20px;
+        padding: 12px 20px;
         font-size: 13px;
         letter-spacing: 2px;
       }

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -1,5 +1,7 @@
 .header{
+  position: relative;
   padding: 0 10%;
+  box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.2);
   &__block{
     width: 100%;
     min-height: 82px;

--- a/app/assets/stylesheets/pages/items/_show.scss
+++ b/app/assets/stylesheets/pages/items/_show.scss
@@ -165,6 +165,12 @@
           }
           &__table {
             margin-bottom: 20px;
+            &__link {
+              &:hover {
+                text-decoration: underline;
+                opacity: 0.5;
+              }
+            }
             & table {
               width: 100%;
               height: 375px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:index, :show, :search]
+  skip_before_action :authenticate_user!, expect: [:new, :create, :edit, :update, :destory]
   before_action :set_item_search_query, expect: [:search]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_present?, only: [:show, :edit]
@@ -54,17 +54,15 @@ class ItemsController < ApplicationController
         if @search_category.ancestry.nil?
           #親カテゴリ
           @category_child_array = Category.where(ancestry: @search_category.id).pluck(:name, :id)
-          grandchildren_id = @search_category.indirect_ids.sort
-          find_category_item(grandchildren_id)
+          find_category_item( @search_category.subtree_ids)
         elsif @search_category.ancestry.exclude?("/")
           #子カテゴリ
           @category_child = @search_category
           @category_child_array = @search_category.siblings.pluck(:name, :id)
           @category_grandchild_array = @search_category.children
-          grandchildren_id = @search_category.child_ids
-          find_category_item(grandchildren_id)
+          find_category_item( @search_category.subtree_ids)
         end
-          #孫カテゴリはransackで拾う → category_id_in
+          # 孫カテゴリはransackで拾う → category_id_in
       end
     end
     @items = Kaminari.paginate_array(@items).page(params[:page]).per(20)
@@ -138,60 +136,6 @@ class ItemsController < ApplicationController
     else
       @price_range = PriceRange.find(params[:price_id])
     end
-  end
-
-  def search
-    @trading_status = TradingStatus.find [1,3]
-    @keyword = params.require(:q)[:name_or_explanation_cont]
-    @search_parents = Category.where(ancestry: nil).where.not(name: "カテゴリー一覧").pluck(:name)
-
-    sort = params[:sort] || "created_at DESC"      
-    @q = Item.not_draft.search(search_params)
-    if sort == "likes_count_desc"
-      @items = @q.result(distinct: true).select('items.*', 'count(likes.id) AS likes')
-        .left_joins(:likes)
-        .group('items.id')
-        .order('likes DESC')
-        .desc
-    else
-      @items = @q.result(distinct: true).order(sort)
-    end
-    # 販売状況が検索条件にあるとき
-    if trading_status_key = params.require(:q)[:trading_status_id_in]
-      @q = Item.including.search(search_params_for_trading_status)
-      if trading_status_key.count == 1 && trading_status_key == ["3"]
-        sold_items = Item.where.not(buyer_id: nil)
-        @items = @items & sold_items
-      elsif trading_status_key.count == 1 && trading_status_key == ["1"]
-        selling_items = Item.where(buyer_id: nil)
-        @items = @items & selling_items
-      end
-    end
-
-    # カテゴリが検索条件にあるとき
-    if category_key = params.require(:q)[:category_id]
-      if category_key.to_i == 0
-        @search_category = Category.find_by(name: category_key, ancestry: nil)
-      else
-        @search_category = Category.find(category_key)
-      end
-
-      if @search_category.present?
-        if @search_category.ancestry.nil?
-          #親カテゴリ
-          @category_child_array = Category.where(ancestry: @search_category.id).pluck(:name, :id)
-          find_category_item( @search_category.subtree_ids)
-        elsif @search_category.ancestry.exclude?("/")
-          #子カテゴリ
-          @category_child = @search_category
-          @category_child_array = @search_category.siblings.pluck(:name, :id)
-          @category_grandchild_array = @search_category.children
-          find_category_item( @search_category.subtree_ids)
-        end
-          # 孫カテゴリはransackで拾う → category_id_in
-      end
-    end
-    @items = Kaminari.paginate_array(@items).page(params[:page]).per(20)
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
-  skip_before_action :authenticate_user!, expect: [:new, :create, :edit, :update, :destory]
-  before_action :set_item_search_query, expect: [:search]
+  skip_before_action :authenticate_user!, except: [:new, :create, :edit, :update, :destory]
+  before_action :set_item_search_query, except: [:search]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_present?, only: [:show, :edit]
-  before_action :set_categories,  except: [:destroy]
+  before_action :set_categories, except: [:destroy]
   
 # 未ログインで行えるアクション
   def index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User < ApplicationRecord
   has_many :from_messages,class_name: "Message" ,foreign_key: "from_id", dependent: :destroy
   has_many :evaluations
   
-  
   with_options presence: true do
     validates :nickname
     validates :last_name

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,5 +1,5 @@
 .item-list.hover
-  = link_to item_path(item),class: "item" do
+  = link_to item_path(item), class: "item" do
     = image_tag "#{item.images[0].image.url}", class: 'item-img'
     -if item.buyer_id.present? 
       .items-box_photo__sold

--- a/app/views/items/create.html.haml
+++ b/app/views/items/create.html.haml
@@ -4,7 +4,7 @@
     .sell-notification.form-container
       %h3.sell-notification__title 出品が完了しました
       %span<> 出品した商品は「
-      = link_to '出品した商品', '#', class: 'sell-notification__link'
+      = link_to '出品した商品', exhibition_users_path, class: 'sell-notification__link'
       %span<> 」からいつでも見ることができます
       .item-btn-area
         .item-btn-area__container

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -50,70 +50,58 @@
                   %tr
                     %th 出品者
                     %td
-                      = link_to user_path do
-                        = @user.nickname
+                      = link_to '#' do
+                        %span= @user.nickname
                   %tr
                     %th カテゴリー
                     %td
-                      = link_to category_path(@item.category.root_id) do
-                        =@item.category.root.name
+                      = link_to category_path(@item.category.root_id), class: "itembox__table__link" do
+                        %span= @item.category.root.name
                       %br
-                      = link_to category_path(@item.category.parent_id) do
-                        =@item.category.parent.name
+                      = link_to category_path(@item.category.parent_id), class: "itembox__table__link" do
+                        %i.fas.fa-chevron-right
+                        %span= @item.category.parent.name
                       %br
-                      = link_to category_path(@item.category) do
-                        =@item.category.name
+                      = link_to category_path(@item.category), class: "itembox__table__link" do
+                        %i.fas.fa-chevron-right
+                        %span= @item.category.name
                   %tr
                     %th 商品の状態
                     %td 
-                      = @item.status.name
+                      %span= @item.status.name
                   %tr
                     %th 配送料の負担
                     %td 
-                      = delivery_charge_full(@item)
+                      %span= delivery_charge_full(@item)
                   %tr
                     %th 発送元の地域
                     %td
-                      = link_to '#' do
-                        = @item.prefecture.name
+                      %span= @item.prefecture.name
                   %tr
                     %th 発送日の目安
                     %td
-                      = @item.delivery_date.name
+                      %span= @item.delivery_date.name
                   %tr
                     %th 配送方法
                     %td
-                      = @item.delivery_method.name
+                      %span= @item.delivery_method.name
             .itembox__option
               = render partial: 'likes/like', locals: { item: @item}
-              %ul.optical
-                %li.report-btn
-                  = link_to '#' do
-                    %i.fa.fa-flag
-                    不適切な商品の通報
           .commentbox
             %ul.commentbox__contents
             %form{class: 'new__comment', action: '#',method:'post', id:'new__comment'}
               %input{type: 'hidden', value: '✓'}
               %textarea.comment__body
               %p.notice__message
-                相手のことを考え丁寧なコメントを心がけましょう。
+                %span 相手のことを考え丁寧なコメントを心がけましょう。
                 %br
-                不快な言葉遣いなどは利用制限や退会処分となることがあります。 
-                %br             
+                %span 不快な言葉遣いなどは利用制限や退会処分となることがあります。 
               %button.comment__btn
                 %i.fa.fa-comment
-                  コメントする
-        .main-item__content--links
-          %li
-            = link_to "前の商品", item_path(@item.id - 1)
-            %i.fa.fa-angle-left
-          %li
-            = link_to "後ろの商品",item_path(@item.id + 1)
-            %i.fa.fa-angle-right
+                %span コメントする
         .main-item__content--related
-          =link_to  category_path(@item.category.root_id) do
+          = link_to  category_path(@item.category.root_id) do
             = @item.category.root.name
-            をもっと見る
+            %span をもっと見る
   = render "shared/footer-image"
   = render "shared/footer"


### PR DESCRIPTION
# What
リンク先のないリンクを削除orリンク設置

1. 商品出品完了後ページの「出品した商品」にリンク設置
2. ~~商品詳細ページの「出品者」からリンク削除~~
 → 前田さんが実装
3. 商品詳細ページの「発送元の地域」からリンク削除
4. 商品詳細ページの「不適切な商品の通報」を削除
5. ~~商品詳細ページの「後ろの商品」を「次の商品」へ~~
 → 商品詳細ページの「前の商品」「後ろの商品」のリンク削除
6. jsのカテゴリポップアップに枠線をつける

# Why
ユーザビリティ向上のため