### PR TITLE
モーダルウィンドウで画像をスライド表示

### DIFF
--- a/app/assets/javascripts/item_post_form.js
+++ b/app/assets/javascripts/item_post_form.js
@@ -351,9 +351,8 @@ $(function(){
       fileReader.readAsDataURL(file);
       const num = i
 
-      
     //画像が10枚になったら超えたらドロップボックスを削除する
-      if (num == 10){
+      if (currentNum + i + 1 >= 10){
         $('#image-box__container').css('display', 'none')
         fileReader.onloadend = function() {
           fileIndex += 1;
@@ -411,9 +410,10 @@ $(function(){
         $.each(files, function(i,file){
           const fileReader = new FileReader();
           fileReader.readAsDataURL(file);
-          const inputNum = $('.item-image').length + add_files_length
+          const currentNum = $('.item-image').length
+          const inputNum = currentNum + add_files_length
           const num = i
-          if (num==10){
+          if (currentNum + i + 1 >= 10){
             $('#image-box__container').css('display', 'none')
             fileReader.onloadend = function() {
               fileIndex += 1;

--- a/app/assets/javascripts/item_show.js
+++ b/app/assets/javascripts/item_show.js
@@ -41,4 +41,38 @@ $(function() {
     });
     $(thumbnailImages+'[data-index="'+nextSlide+'"]').addClass("thumbnail-current");
   });
+  
+  // モーダルの挙動
+  $('[data-modal="overlay"], [data-modal="content"]').hide();
+  
+  const modal_slider = "#slider_images_modal"
+
+  $(sliderImages).on('click', function() {
+    index = Number($(this).attr("data-slick-index"))
+    $(modal_slider).slick({
+      prevArrow: '<i class="fa fa-angle-left arrow arrow-left"></i>',
+      nextArrow: '<i class="fa fa-angle-right arrow arrow-right"></i>',
+      dots: true,
+      speed: 800,
+      initialSlide: index
+    });
+    posi = $(window).scrollTop();
+    $('[data-modal="fixed"]').css({
+      position: 'fixed',
+      top: -1 * posi
+    });
+    $('[data-modal="overlay"], [data-modal="content"]').fadeIn();
+    $(modal_slider).css('opacity',0);
+    $(modal_slider).animate({'z-index':1},500,function(){
+      $(modal_slider).slick('setPosition');
+      $(modal_slider).animate({'opacity':1});
+    });
+  });
+  
+  $('.js_modal_close, [data-modal="overlay"]').on('click', function(){
+    $('[data-modal="fixed"]').attr('style', '');
+    $('html, body').prop({scrollTop: posi});
+    $('[data-modal="overlay"], [data-modal="content"]').fadeOut();
+    $(modal_slider).slick('unslick')
+  });
 });

--- a/app/assets/javascripts/item_show.js
+++ b/app/assets/javascripts/item_show.js
@@ -1,0 +1,44 @@
+$(function() {
+  const slider = "#slider_images";
+  const sliderImages = "#slider_images .slider_image"
+  const thumbnailImages = "#thumb_images .thumb_image";
+  let image_index;
+  let index;
+
+  // 画像にindexを振る
+  $(thumbnailImages).each(function() {
+    image_index = $(thumbnailImages).index(this);
+    if (image_index == 0) {
+      $(this).addClass("thumbnail-current")
+    }
+    $(this).attr("data-index", image_index);
+  });
+
+  // 画像のindexをもとに、サムネイルで選択中の画像にクラスを付与
+  $(slider).on('init', function(slick) {
+    index = $(".slide-item.slick-slide.slick-current").attr("data-slick-index");
+    $(thumbnailImages+'[data-index="'+index+'"]').addClass("thumbnail-current");
+   });
+ 
+  //slickスライダー定義
+  $(slider).slick({
+    prevArrow:'<i class="fa fa-angle-left arrow arrow-left"></i>',
+    nextArrow:'<i class="fa fa-angle-right arrow arrow-right"></i>',
+    fade: true,
+    infinite: true,
+  });
+
+  //サムネイル画像アイテムをクリックしたときにスライダー切り替え
+  $(thumbnailImages).on('click', function(){
+    index = $(this).attr("data-index");
+    $(slider).slick("slickGoTo",index,false);
+  });
+
+  //サムネイル画像のクラスを切り替え
+  $(slider).on('beforeChange',function(event, slick, currentSlide, nextSlide){
+    $(thumbnailImages).each(function(){
+      $(this).removeClass("thumbnail-current");
+    });
+    $(thumbnailImages+'[data-index="'+nextSlide+'"]').addClass("thumbnail-current");
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
+@import "slick-theme.scss";
 @import "reset";
 @import "config/color";
 @import "mixin/mixin";

--- a/app/assets/stylesheets/pages/items/_show.scss
+++ b/app/assets/stylesheets/pages/items/_show.scss
@@ -9,63 +9,61 @@
       &--form {
         .itembox {
           background-color: #fff;
-          padding: 24px 70px 40px;
+          padding: 8px 90px 40px;
           &__name {
+            margin-bottom: 20px;
             text-align: center;
             font-weight: bold;
             font-size: 24px;
           }
-          &__image {
-            margin: 16px 0 0;
-            & ul {
+          &__image-container {
+            &__target {
               display: flex;
               position: relative;
-              & li {
-                display: flex;
-                flex-direction: column;
-                width: 560px;
-                align-items: center;
+              background-color: $whitesmoke;
+              .sold-item {
+                width: 0;
+                height: 0;
+                border-width: 160px 160px 0 0;
+                border-color: #ea352d transparent transparent transparent;
+                display: block;
+                position: absolute;
+                top: 0;
+                left: 0;
+                z-index: 1;
+                border-style: solid;
+                &__inner {
+                  top: -130px;
+                  font-size: 34px;
+                  position: absolute;
+                  left: 0;
+                  z-index: 2;
+                  color: #fff;
+                  transform: rotate(-45deg);
+                  letter-spacing: 2px;
+                  font-weight: 600;
+                }
+              }
+              &__box {
                 margin: 0 auto;
                 & img {
-                  object-fit: cover;
-                  height: 346px;
                   width: 100%;
-                  vertical-align: bottom;
-                }
-                .mini-image {
-                  width: 560px;
-                  font-size: 0;
-                  &s {
-                    display: inline-block;
-                    & img {
-                      width: 112px;
-                      height: 87px;
-                    }
-                  }
-                }
-                
-                .sold-item {
-                  width: 0;
-                  height: 0;
-                  border-width: 160px 160px 0 0;
-                  border-color: #ea352d transparent transparent transparent;
-                  display: block;
-                  position: absolute;
-                  top: 0;
-                  left: 0;
-                  z-index: 1;
-                  border-style: solid;
-                  &__inner {
-                    top: -130px;
-                    font-size: 34px;
-                    position: absolute;
-                    left: 0;
-                    z-index: 2;
-                    color: #fff;
-                    transform: rotate(-45deg);
-                    letter-spacing: 2px;
-                    font-weight: 600;
-                  }
+                  height: 320px;
+                  object-fit: contain;
+                }  
+              }
+            }
+            &__thumb-list {
+              display: flex;
+              align-items: center;
+              width: 520px;
+              background-color: $whitesmoke;
+              &__thumb {
+                width: 104px;
+                & img {
+                  width: 104px;
+                  height: 104px;
+                  object-fit: fill;
                 }
               }
             }

--- a/app/assets/stylesheets/pages/items/_show.scss
+++ b/app/assets/stylesheets/pages/items/_show.scss
@@ -1,6 +1,7 @@
 .main {
   background: #f8f8f8;
   &-item {
+    position: relative;
     padding: 40px;
     margin: 0 auto;
     &__content {
@@ -17,49 +18,76 @@
             font-size: 24px;
           }
           &__image-container {
-            &__target {
-              display: flex;
-              position: relative;
-              background-color: $whitesmoke;
-              .sold-item {
-                width: 0;
-                height: 0;
-                border-width: 160px 160px 0 0;
-                border-color: #ea352d transparent transparent transparent;
-                display: block;
+            position: relative;
+            .sold-item {
+              width: 0;
+              height: 0;
+              border-width: 160px 160px 0 0;
+              border-color: #ea352d transparent transparent transparent;
+              display: block;
+              position: absolute;
+              top: 0;
+              left: 0;
+              z-index: 1;
+              border-style: solid;
+              &__inner {
+                top: -130px;
+                font-size: 34px;
                 position: absolute;
-                top: 0;
                 left: 0;
-                z-index: 1;
-                border-style: solid;
-                &__inner {
-                  top: -130px;
-                  font-size: 34px;
-                  position: absolute;
-                  left: 0;
-                  z-index: 2;
-                  color: #fff;
-                  transform: rotate(-45deg);
-                  letter-spacing: 2px;
-                  font-weight: 600;
-                }
+                z-index: 2;
+                color: #fff;
+                transform: rotate(-45deg);
+                letter-spacing: 2px;
+                font-weight: 600;
               }
+            }
+            &__slider {
+              display: flex;
+              align-items: center;
+              margin: 0 0;
+              background-color: $whitesmoke;
+              font-size: 60px;
+              color: lightgray;
               &__box {
                 margin: 0 auto;
+                &:focus {
+                  outline: none;
+                  border: none;
+                }
                 & img {
                   width: 100%;
                   height: 320px;
                   object-fit: contain;
+                  cursor: pointer;
                 }  
               }
             }
-            &__thumb-list {
+            &__thumb {
               display: flex;
+              flex-wrap: wrap;
               align-items: center;
               width: 520px;
               background-color: $whitesmoke;
-              &__thumb {
+              &__box {
+                position: relative;
                 width: 104px;
+                height: 104px;
+                &:after{
+                  content:'';
+                  background-color: rgba(0,0,0,0.5);
+                  position:absolute;
+                  display: block;
+                  top: 0;
+                  left: 0;
+                  width: 100%;
+                  height: 100%;
+                  opacity: 1;
+                  transition: .3s opacity linear;
+                }
+                &.thumbnail-current:after{
+                  opacity: 0;
+                }
                 & img {
                   width: 104px;
                   height: 104px;
@@ -305,6 +333,69 @@
           position: relative;
         }      
       }
+    }
+
+    #item-modal__content {
+      position: fixed;
+      top: 10%;
+      bottom: 0;
+      right: 0;
+      left: 20%;
+      width: 60%;
+      height: 80%;
+      border-radius: 10px;
+      background-color: white;
+      z-index: 100;
+      .item-modal__times {
+        padding: 24px;
+        text-align: right;
+        .fa-times {
+          cursor: pointer;
+        }
+      }
+      .item-modal__slider {
+        position: relative;
+        padding-bottom: 24px;
+        font-size: 60px;
+        .slick-arrow {
+          position: absolute;
+          top: 40%;
+          cursor: pointer;
+        }
+        .arrow-right {
+          position: absolute;
+          right: 2%;
+          z-index: 100;
+        }
+        .arrow-left {
+          position: absolute;
+          left: 2%;
+          z-index: 100;
+        }
+        &__box {
+          display: flex;
+          &:focus {
+            outline: none;
+            border: none;
+          }
+          & img {
+            display: block;
+            margin: 0 auto;
+            max-height: 480px;
+            height: 100%;
+            object-fit: fill;
+          }  
+        }
+      }
+    }
+    #item-modal__overlay {
+      background: rgba(0,0,0,0.5);
+      width: 100%;
+      height: 100vh;
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 99;
     }
   }
 }

--- a/app/assets/stylesheets/slick-theme.scss
+++ b/app/assets/stylesheets/slick-theme.scss
@@ -1,0 +1,195 @@
+@charset "UTF-8";
+
+// Default Variables
+
+// Slick icon entity codes outputs the following
+// "\2190" outputs ascii character "←"
+// "\2192" outputs ascii character "→"
+// "\2022" outputs ascii character "•"
+
+$slick-font-path: "./fonts/" !default;
+$slick-font-family: "slick" !default;
+$slick-loader-path: "./" !default;
+$slick-arrow-color: white !default;
+$slick-dot-color: black !default;
+$slick-dot-color-active: $slick-dot-color !default;
+$slick-prev-character: "\2190" !default;
+$slick-next-character: "\2192" !default;
+$slick-dot-character: "\2022" !default;
+$slick-dot-size: 40px !default;
+$slick-opacity-default: 0.75 !default;
+$slick-opacity-on-hover: 1 !default;
+$slick-opacity-not-active: 0.25 !default;
+
+@function slick-image-url($url) {
+    @if function-exists(image-url) {
+        @return image-url($url);
+    }
+    @else {
+        @return url($slick-loader-path + $url);
+    }
+}
+
+@function slick-font-url($url) {
+    @if function-exists(font-url) {
+        @return font-url($url);
+    }
+    @else {
+        @return url($slick-font-path + $url);
+    }
+}
+
+/* Slider */
+
+.slick-list {
+    display: inline;
+    .slick-loading & {
+        background: #fff slick-image-url("ajax-loader.gif") center center no-repeat;
+    }
+}
+
+/* Icons */
+@if $slick-font-family == "slick" {
+    @font-face {
+        font-family: "slick";
+        src: slick-font-url("slick.eot");
+        src: slick-font-url("slick.eot?#iefix") format("embedded-opentype"), slick-font-url("slick.woff") format("woff"), slick-font-url("slick.ttf") format("truetype"), slick-font-url("slick.svg#slick") format("svg");
+        font-weight: normal;
+        font-style: normal;
+    }
+}
+
+/* Arrows */
+
+.slick-prev,
+.slick-next {
+    position: absolute;
+    // display: block;
+    height: 20px;
+    width: 20px;
+    line-height: 0px;
+    font-size: 0px;
+    cursor: pointer;
+    background: transparent;
+    color: transparent;
+    top: 50%;
+    -webkit-transform: translate(0, -50%);
+    -ms-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+    padding: 0;
+    border: none;
+    outline: none;
+    &:hover, &:focus {
+        outline: none;
+        background: transparent;
+        color: transparent;
+        &:before {
+            opacity: $slick-opacity-on-hover;
+        }
+    }
+    &.slick-disabled:before {
+        opacity: $slick-opacity-not-active;
+    }
+    &:before {
+        font-family: $slick-font-family;
+        font-size: 20px;
+        line-height: 1;
+        color: $slick-arrow-color;
+        opacity: $slick-opacity-default;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+    }
+}
+
+.slick-prev {
+    left: -25px;
+    [dir="rtl"] & {
+        left: auto;
+        right: -25px;
+    }
+    &:before {
+        content: $slick-prev-character;
+        [dir="rtl"] & {
+            content: $slick-next-character;
+        }
+    }
+}
+
+.slick-next {
+    right: -25px;
+    [dir="rtl"] & {
+        left: -25px;
+        right: auto;
+    }
+    &:before {
+        content: $slick-next-character;
+        [dir="rtl"] & {
+            content: $slick-prev-character;
+        }
+    }
+}
+
+/* Dots */
+
+.slick-dotted.slick-slider {
+    margin-bottom: 30px;
+}
+
+.slick-dots {
+    position: absolute;
+    bottom: -25px;
+    list-style: none;
+    display: block;
+    text-align: center;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    li {
+        position: relative;
+        display: inline-block;
+        height: 20px;
+        width: 20px;
+        margin: 0 16px;
+        padding: 0;
+        cursor: pointer;
+        button {
+            border: 0;
+            background: transparent;
+            display: block;
+            height: 20px;
+            width: 20px;
+            outline: none;
+            line-height: 0px;
+            font-size: 0px;
+            color: transparent;
+            padding: 5px;
+            cursor: pointer;
+            &:hover, &:focus {
+                outline: none;
+                &:before {
+                    opacity: $slick-opacity-on-hover;
+                }
+            }
+            &:before {
+                position: absolute;
+                top: 0;
+                left: 0;
+                content: $slick-dot-character;
+                width: 20px;
+                height: 20px;
+                font-family: $slick-font-family;
+                font-size: $slick-dot-size;
+                line-height: 20px;
+                text-align: center;
+                color: $slick-dot-color;
+                opacity: $slick-opacity-not-active;
+                -webkit-font-smoothing: antialiased;
+                -moz-osx-font-smoothing: grayscale;
+            }
+        }
+        &.slick-active button:before {
+            color: $slick-dot-color-active;
+            opacity: $slick-opacity-default;
+        }
+    }
+}

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -7,19 +7,19 @@
           .itembox
             %h2.itembox__name
               = @item.name.truncate(30, omission: '...')
-            .itembox__image
-              %ul
-                %li
+            .itembox__image-container
+              .itembox__image-container__target
+                .itembox__image-container__target__box
                   = image_tag @item.images[0].image.url
                     - if @item.buyer_id.present?
                     .sold-item
                       .sold-item__inner
                         SOLD
-                  .mini-image
-                    - @item.images.each_with_index do |image, i|
-                      - unless i == 0
-                        .mini-images
-                          =image_tag image.image.url
+              %ul.itembox__image-container__thumb-list
+                - if @item.images.count > 1
+                  - @item.images.each_with_index do |image, i|
+                    %li.itembox__image-container__thumb-list__thumb
+                      = image_tag image.image.url
             .itembox__price
               %span= "¥#{@item.price.to_s(:delimited)}"
               .itembox__price--detail

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,4 +1,4 @@
-.wrapper
+%div{ class: "wrapper", data: {modal: "fixed"}}
   = render "shared/header"
   .main
     .main-item
@@ -8,17 +8,18 @@
             %h2.itembox__name
               = @item.name.truncate(30, omission: '...')
             .itembox__image-container
-              .itembox__image-container__target
-                .itembox__image-container__target__box
-                  = image_tag @item.images[0].image.url
-                    - if @item.buyer_id.present?
-                    .sold-item
-                      .sold-item__inner
-                        SOLD
-              %ul.itembox__image-container__thumb-list
+              %ul.itembox__image-container__slider#slider_images
+                - @item.images.each_with_index do |image, i|
+                  %li.itembox__image-container__slider__box.slider_image
+                    = image_tag image.image.url
+              - if @item.buyer_id.present?
+                .sold-item
+                  .sold-item__inner
+                    SOLD
+              %ul.itembox__image-container__thumb#thumb_images
                 - if @item.images.count > 1
                   - @item.images.each_with_index do |image, i|
-                    %li.itembox__image-container__thumb-list__thumb
+                    %li.itembox__image-container__thumb__box.thumb_image
                       = image_tag image.image.url
             .itembox__price
               %span= "¥#{@item.price.to_s(:delimited)}"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -104,5 +104,13 @@
           = link_to  category_path(@item.category.root_id) do
             = @item.category.root.name
             %span をもっと見る
+      %div{ id: "item-modal__content", data: { modal: "content"}}
+        .item-modal__times
+          %i.fas.fa-times.fa-lg.js_modal_close
+        %ul.item-modal__slider#slider_images_modal
+          - @item.images.each_with_index do |image, i|
+            %li.item-modal__slider__box.slider_image
+              = image_tag image.image.url
+      %div{ id: "item-modal__overlay", data: { modal: "overlay"}}
   = render "shared/footer-image"
   = render "shared/footer"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,12 +4,12 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title FreemarketSample68d
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
-    %meta{:content => "summary_large_image", :name => "twitter:card"}/
-    %meta{:content => "@yGZqMc5IqNbVsw0", :name => "twitter:site"}/
-    %meta{:content => "http://www.furima-68d.work/", :property => "og:url"}/
-    %meta{:content => "freemarket_sample", :property => "og:title"}/
-    %meta{:content => "チーム開発用のサンプルです！是非ご覧になってください！", :property => "og:description"}/
-    %meta{:content => "logo-white.png", :property => "og:image"}/
+    %meta{content: "summary_large_image", name: "twitter:card"}/
+    %meta{content: "@yGZqMc5IqNbVsw0", name: "twitter:site"}/
+    %meta{content: "http://www.furima-68d.work/", property: "og:url"}/
+    %meta{content: "freemarket_sample", property: "og:title"}/
+    %meta{content: "チーム開発用のサンプルです！是非ご覧になってください！", property: "og:description"}/
+    %meta{content: "logo-white.png", property: "og:image"}/
     = favicon_link_tag 'favicon.ico'
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,14 +7,16 @@
     %meta{content: "summary_large_image", name: "twitter:card"}/
     %meta{content: "@yGZqMc5IqNbVsw0", name: "twitter:site"}/
     %meta{content: "http://www.furima-68d.work/", property: "og:url"}/
-    %meta{content: "freemarket_sample", property: "og:title"}/
+    %meta{content: "freemarket_sample", property: "og:title"}/  
     %meta{content: "チーム開発用のサンプルです！是非ご覧になってください！", property: "og:description"}/
     %meta{content: "logo-white.png", property: "og:image"}/
     = favicon_link_tag 'favicon.ico'
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all', data:{ turbolinks:{ track: true }}
+    %link{ rel: "stylesheet", type: "text/css", href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"}
+    = javascript_include_tag 'application', data: { turbolinks: { track: true }}
+    %script{ type: "text/javascript", src: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"}
   %body
     = yield
 


### PR DESCRIPTION
# What
- 商品詳細ページで、画像をモーダルウィンドウで表示
- 複数画像ある場合はスライド表示

# Why
- 画像をより直感的に閲覧することで、ユーザーの購買意欲を妨げないため
- また、画像を簡単に拡大して細部まで閲覧できるようにすることで、商品の状態を確認しやすくし、購買の不安を払拭してハードルを下げるため