### PR TITLE
不要なマイグレーションファイルの消去・rails db:migrate:reset

### DIFF
--- a/db/migrate/20200605101600_create_notifications.rb
+++ b/db/migrate/20200605101600_create_notifications.rb
@@ -5,7 +5,6 @@ class CreateNotifications < ActiveRecord::Migration[5.2]
       t.integer :receiver_id
       t.integer :item_id
       t.string :action
-      t.boolean :checked, default: false, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20200615073747_remove_columns_in_notifications.rb
+++ b/db/migrate/20200615073747_remove_columns_in_notifications.rb
@@ -1,6 +1,0 @@
-class RemoveColumnsInNotifications < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :notifications, :like_id, :integer
-    remove_column :notifications, :comment_id, :integer
-  end
-end

--- a/db/migrate/20200618215024_change_data_checked_to_notifications.rb
+++ b/db/migrate/20200618215024_change_data_checked_to_notifications.rb
@@ -1,9 +1,0 @@
-class ChangeDataCheckedToNotifications < ActiveRecord::Migration[5.2]
-  def up
-    change_column :notifications, :checked, :boolean, default: false, null: false
-  end
-
-  def down
-    change_column :notifications, :checked, :boolean, null: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_215024) do
+ActiveRecord::Schema.define(version: 2020_06_07_051917) do
 
   create_table "accounts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -122,7 +122,6 @@ ActiveRecord::Schema.define(version: 2020_06_18_215024) do
     t.integer "receiver_id"
     t.integer "item_id"
     t.string "action"
-    t.boolean "checked", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
# What
- エラーの原因となるマイグレーションファイルの消去

# Why
- notificationsテーブルの不必要なカラム（like_id, comment_id, checked）に変更を加えた際に発生したマイグレーションファイルの除去を行った