### PR TITLE
通知エラーの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,6 +58,8 @@ class ApplicationController < ActionController::Base
   end
 
   def my_notifications
-    @notifications = current_user.passive_notifications.preload(:item, sender: :account)
+    if current_user.present?
+      @notifications = current_user.passive_notifications.preload(:item, sender: :account)
+    end
   end
 end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,20 +1,13 @@
 class TopsController < ApplicationController
   skip_before_action :authenticate_user!
-  before_action :set_notice
   before_action :set_item_search_query
   before_action :set_categories,  only: [:index]
+  before_action :my_notifications
   
   def index  
     @items = Item.including.limit(5).desc.trading_not
   end
   
   def new
-  end
-
-  private
-  def set_notice
-    if current_user.present?
-      @notifications = current_user.passive_notifications.preload(:item, sender: :account)
-    end
   end
 end


### PR DESCRIPTION
# What
- ログインしていないユーザーの通知を取得してしまうエラーを解消

# Why
- current_userで条件分岐することによって、ログインしていない状態のエラーを防ぐ