### PR TITLE
fix: 商品画像のモーダルウィンドウのサイズを固定に

### DIFF
--- a/app/assets/stylesheets/pages/items/_show.scss
+++ b/app/assets/stylesheets/pages/items/_show.scss
@@ -343,8 +343,8 @@
       bottom: 0;
       right: 0;
       left: 20%;
-      width: 60%;
-      height: 80%;
+      width: 880px;
+      height: 640px;
       border-radius: 10px;
       background-color: white;
       z-index: 100;


### PR DESCRIPTION
# What
商品画像のモーダルウィンドウのサイズを固定に

# Why
ブラウザの幅や高さに応じて表示が崩れるのを防ぐため
